### PR TITLE
Adding autoload support for traits (php>=5.4) to Zend_Loader

### DIFF
--- a/library/Zend/Loader.php
+++ b/library/Zend/Loader.php
@@ -51,7 +51,7 @@ class Zend_Loader
      */
     public static function loadClass($class, $dirs = null)
     {
-        if (class_exists($class, false) || interface_exists($class, false)) {
+        if (self::_isLoaded($class)) {
             return;
         }
 
@@ -82,7 +82,7 @@ class Zend_Loader
             self::loadFile($file, null, true);
         }
 
-        if (!class_exists($class, false) && !interface_exists($class, false)) {
+        if (!self::_isLoaded($class)) {
             require_once 'Zend/Exception.php';
             throw new Zend_Exception("File \"$file\" does not exist or class \"$class\" was not found in the file");
         }
@@ -290,6 +290,23 @@ class Zend_Loader
             require_once 'Zend/Exception.php';
             throw new Zend_Exception('Security check: Illegal character in filename');
         }
+    }
+
+    /**
+     * Check if a given classname is loaded as either a class, an interface or
+     * (if supported) a trait.
+     *
+     * @param string $class
+     * @return boolean
+     */
+    protected static function _isLoaded($class)
+    {
+        $classLoaded = class_exists($class, false) || interface_exists($class, false);
+        if (function_exists('trait_exists'))
+        {
+            $classLoaded = $classLoaded || trait_exists($class, false);
+        }
+        return $classLoaded;
     }
 
     /**

--- a/tests/Zend/LoaderTest.php
+++ b/tests/Zend/LoaderTest.php
@@ -132,6 +132,21 @@ class Zend_LoaderTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testLoaderTraitViaLoadClass()
+    {
+        if (!function_exists('trait_exists')) {
+            $this->markTestSkipped('traits are only available in php >=5.4.0');
+        }
+
+        $dir = implode(array(dirname(__FILE__), '_files', '_testDir1'), DIRECTORY_SEPARATOR);
+
+        try {
+            Zend_Loader::loadClass('Trait1', $dir);
+        } catch (Zend_Exception $e) {
+            $this->fail('Loading traits should not fail');
+        }
+    }
+
     public function testLoaderLoadClassWithDotDir()
     {
         $dirs = array('.');

--- a/tests/Zend/_files/_testDir1/Trait1.php
+++ b/tests/Zend/_files/_testDir1/Trait1.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+
+/**
+ * Empty trait that is used in unit testing by Zend_LoaderTest::testLoaderTraitViaLoadClass()
+ *
+ * @category   Zend
+ * @package    Zend_Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+trait Trait1
+{
+}


### PR DESCRIPTION
This is a small patch which updates `Zend_Loader`to play nicely with traits .

- split an isLoaded method out of loadClass to check if loading the
class, interface or trait was successful
- added unit tests
- keeping care of php versions <5.4